### PR TITLE
*_pinyin: 宁/zhu4,ning2,ning4/，㤅/ai4/，磑磑/ai2 ai2/

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -257,6 +257,7 @@ use_preset_vocabulary: true
 㣔	cheng
 㣔	zheng
 㣺	xin
+㤅	ai
 㤈	qin
 㤉	qia
 㤋	fen
@@ -5165,8 +5166,8 @@ use_preset_vocabulary: true
 孿	luan
 孿	lvan
 宀	mian
-宁	ning
-宁	zhu
+宁	ning	0%
+宁	zhu	100%
 宂	rong
 它	ta	100%
 它	tuo	0%
@@ -31662,7 +31663,6 @@ use_preset_vocabulary: true
 孿生	luan sheng
 孿生兄弟	luan sheng xiong di
 孿生子	luan sheng zi
-宁立	zhu li
 它們	tuo men
 它囂	tuo xiao
 它山之石	tuo shan zhi shi
@@ -39989,6 +39989,7 @@ use_preset_vocabulary: true
 磅薄	pang bo
 磈磊	kui lei
 磊砢	lei luo
+磑磑	ai ai
 磔刑	zhe xing
 磔磔	zhe zhe
 磕磕撞撞	ke ke zhuang zhuang

--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -55,6 +55,7 @@ min_phrase_weight: 100
 㞎	pa2
 㞞	song2
 㟏岈	han1 xia1
+㤅	ai4
 㥁	de2
 㥄遽	ling2 ju4
 㥏墨	tian3 mo4
@@ -16105,7 +16106,9 @@ min_phrase_weight: 100
 孿	luan2
 孿生素數	luan2 sheng1 su4 shu4
 宀	mian2
-宁立	zhu4 li4
+宁	ning2	0%
+宁	ning4	0%
+宁	zhu4	100%
 它	ta1
 它們	tuo1 men5
 它囂	tuo1 xiao1
@@ -20812,14 +20815,14 @@ min_phrase_weight: 100
 忿悁	fen4 juan4
 怊悵	chao1 chang4
 怍	zuo4
-怎	zen3
 怎	ze3
+怎	zen3
 怎地	zen3 de5
 怎麼得了	zen3 me5 de2 liao3
 怎麼搞的	ze3 me5 gao3 de5
 怎麼着	zen3 me5 zhao1
-怎麽	zen3 me5
 怎麽	ze3 me5
+怎麽	zen3 me5
 怎麽了	zen3 me5 le5
 怏	yang4
 怏怏不樂	yang4 yang4 bu4 le4
@@ -49968,8 +49971,8 @@ min_phrase_weight: 100
 蠼猱	jue2 nao2
 蠼螋	jue2 sou1
 蠽	jie2
-血	xue4
 血	xie3
+血	xue4
 血不歸經	xie3 bu4 gui1 jing1
 血不歸經	xue4 bu4 gui1 jing1
 血中毒	xie3 zhong4 du2
@@ -57246,10 +57249,9 @@ min_phrase_weight: 100
 銍	zhi4
 銍艾	zhi4 yi4
 銎	qiong1
-銑	xian3
 銑	xi3
+銑	xian3
 銑鋧	xian3 xian4
-鋧	xian4
 銓	quan2
 銕	yi2
 銖	zhu1
@@ -57342,6 +57344,7 @@ min_phrase_weight: 100
 鋦	ju1	50%
 鋦	ju2	50%
 鋦子	ju1 zi5
+鋧	xian4
 鋨	e2
 鋩	mang2
 鋪	pu1	50%


### PR DESCRIPTION
按：「宁」的ning4、ning2二音是繼承自「寧」的讀音，其本身承擔的讀音只有「zhu4」。故把ning4、ning2音降爲0%，使「宁」不被看作多音字而自動注音。
