### PR TITLE
修正「宁」組詞時出現ning音

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -11294,7 +11294,6 @@ use_preset_vocabulary: true
 孿	luan
 孿	lvan
 宀	mian
-宁	ning	0%
 宁	zhu	100%
 宂	rong
 它	ta	100%


### PR DESCRIPTION
這件事情很奇怪，「宁」的簡化字音ning音明明註上0%，但是仍然會參與詞組自動注音，如「扆宁」、「位宁」等詞語（在朙月拼音擴充詞庫中，等待自動注音）中。正確的讀音只應該有zhu，不應該有ning才對。
