### PR TITLE
x_pinyin: [㒯曗爗燁曄曅]修正錯音

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -186,7 +186,6 @@ use_preset_vocabulary: true
 㒧	li
 㒩	luo
 㒫	ji
-㒯	hua
 㒯	ye
 㒰	quan
 㒲	cai
@@ -14983,9 +14982,7 @@ use_preset_vocabulary: true
 曁	ji
 曂	huang
 曃	tai
-曄	hua
 曄	ye
-曅	hua
 曅	ye
 曆	li
 曇	tan
@@ -15012,7 +15009,6 @@ use_preset_vocabulary: true
 曔	jing
 曕	yan
 曖	ai
-曗	hua
 曗	ye
 曘	ru
 曙	shu
@@ -18434,7 +18430,6 @@ use_preset_vocabulary: true
 熾	zhi	0%
 熿	huang
 燀	chan
-燁	hua
 燁	ye
 燂	qian
 燂	tan
@@ -18539,7 +18534,6 @@ use_preset_vocabulary: true
 爔	xi
 爕	xie
 爖	long
-爗	hua
 爗	ye
 爙	rang
 爙	shang
@@ -57633,7 +57627,6 @@ use_preset_vocabulary: true
 暴風驟雨	bao feng zou yu
 暴骨	pu gu
 暴骨原野	pu gu yuan ye
-曄曄	ye ye
 曉伏夜行	xiao fu ye xing
 曉行夜宿	xiao xing ye su
 曛黑	xun he
@@ -60416,7 +60409,6 @@ use_preset_vocabulary: true
 焯爍	zhuo shuo
 焯著	zhuo zhu
 煎聒	jian gua
-煒燁	wei ye
 煖和	nuan huo
 煖房	nuan fang
 煖爐	nuan lu
@@ -60548,9 +60540,6 @@ use_preset_vocabulary: true
 熱門音樂	re men yin yue
 熲熲	jiong jiong
 熾盛	chi sheng
-燁然	ye ran
-燁煜	ye yu
-燁燁	ye ye
 燂爍	qian shuo
 燃犀溫嶠	ran xi wen qiao
 燃膏繼晷	ran gao ji gui
@@ -64040,7 +64029,6 @@ use_preset_vocabulary: true
 茂行	mao xing
 范公堤	fan gong di
 范公堤	fan gong ti
-范曄	fan ye
 范雎	fan ju
 茄克	jia ke
 茄冬	jia dong
@@ -66566,7 +66554,6 @@ use_preset_vocabulary: true
 趙令畤	zhao ling zhi
 趙伯駒	zhao bo ju
 趙孟頫	zhao meng fu
-趙曄	zhao ye
 趙衰	zhao cui
 趨之若鶩	qu zhi ruo wu
 趨蹌	qu qiang
@@ -69368,7 +69355,6 @@ use_preset_vocabulary: true
 韜聲匿跡	tao sheng ni ji
 韞櫝而藏	yun du er cang
 韞櫝藏珠	yun du cang zhu
-韡曄	wei ye
 音樂	yin yue
 音樂人	yin yue ren
 音樂劇	yin yue ju

--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -39808,7 +39808,6 @@ min_phrase_weight: 100
 李斯特氏菌	li3 si1 te4 shi4 jun1
 李斯特菌	li3 si1 te4 jun1
 李昌鎬	li3 chang1 hao4
-李曄	li1 ye4
 李朝威	li3 chao2 wei1
 李氏朝鮮	li3 shi4 chao2 xian3
 李漁叔	li3 yu2 shu2


### PR DESCRIPTION
[㒯曗爗燁曄曅]是單音字，沒有hua音。
hua屬於錯音，當成容錯音不可接受。

另外我發現地球拼音中的讀音要純正多了，沒有導入這種錯音。
