### PR TITLE
添加對敎院式支持

### DIFF
--- a/supplement/jyutping.schema.yaml
+++ b/supplement/jyutping.schema.yaml
@@ -53,6 +53,7 @@ speller:
   algebra:
     - abbrev/^([a-z]).+$/$1/
     - derive/^j([aeiou])/y$1/
+    - derive/^jyu/ju/
     - derive/yu/y/
     - derive/z/dz/
     - derive/c/ts/
@@ -63,7 +64,7 @@ speller:
 
 translator:
   dictionary: jyutping
-  spelling_hints: 5
+  spelling_hints: 4
 
 reverse_lookup:
   dictionary: luna_pinyin


### PR DESCRIPTION
在不造或明顯歧義的情形下添加對敎院式粵拼支持。敎院式爲香港教育統籌局及香港考試局等香港教育部門，唯一承認的標準粵語拼音方案。
