### PR TITLE
x_pinyin: 修正「厷」讀音

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -28,7 +28,7 @@
 
 ---
 name: luna_pinyin
-version: "2014.01.14"
+version: "2014.01.25"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -8704,7 +8704,9 @@ use_preset_vocabulary: true
 厴	yan
 厵	yuan
 厶	si
-厷	qu
+厷	gong
+厷	hong
+厷	you	0%
 厸	lin
 厸	mian
 厹	qiu

--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -23,7 +23,7 @@
 
 ---
 name: terra_pinyin
-version: "2014.01.16"
+version: "2014.01.25"
 sort: by_weight
 use_preset_vocabulary: true
 max_phrase_length: 7
@@ -17057,6 +17057,7 @@ min_phrase_weight: 100
 厶	si1
 厷	gong1
 厷	hong2
+厷	you4	0%
 厸	lin2
 厸	mian3
 厹	qiu2	50%


### PR DESCRIPTION
分別爲「肱」初文、「宏」異體、「右」異寫字。見：http://chardb.iis.sinica.edu.tw/search.jsp?q=%E5%8E%B7&x=-761&y=-138&stype=0
