### PR TITLE
remove duplicate entry "哼" of "pinyin_simp.dict.yaml".

### DIFF
--- a/supplement/pinyin_simp.dict.yaml
+++ b/supplement/pinyin_simp.dict.yaml
@@ -6569,7 +6569,6 @@ sort: by_weight
 葵	kui	397
 奎	kui	670
 亏	kui	4988
-哼	heng	2072
 蘤	hua	0
 鏵	hua	0
 鷨	hua	1


### PR DESCRIPTION
Line 6572: 哼  heng    2072
Line 7033: 哼  heng    2072

This suppress the following warning:

> entry_collector.cc:194] duplicate word definition '哼': [heng].
