### PR TITLE
耶魯拼音: 修正提示拼音錯誤 

### DIFF
--- a/supplement/yale.schema.yaml
+++ b/supplement/yale.schema.yaml
@@ -74,7 +74,7 @@ translator:
     - xform/j/y/
     - xform/z/j/
     - xform/c/ch/
-    - xform/aa$/a/
+    - xform/aa(\>|$)/a/
     - xform/eu/iu/
     - xform/eo/eu/
     - xform/oe/eu/


### PR DESCRIPTION
「家禽」 gaa kam -> ga kam