### PR TITLE
yale: 补充声母简拼，修正反查错误

### DIFF
--- a/supplement/yale.schema.yaml
+++ b/supplement/yale.schema.yaml
@@ -64,12 +64,13 @@ speller:
     - xform/ep/ip/           # 夾 gep -> gip
     - abbrev/^([a-z]).+$/$1/ # 首字母簡拼
     - abbrev/^(ng).+$/$1/    # 聲母簡拼
+    - abbrev/^(ch).+$/$1/    # 聲母簡拼
     - abbrev/^([gk]w).+$/$1/ # 聲母簡拼
 
 translator:
   dictionary: jyutping
   spelling_hints: 5
-  comment_format:
+  comment_format: &comment_rules
     - xform/jy/y/
     - xform/j/y/
     - xform/z/j/
@@ -90,17 +91,7 @@ reverse_lookup:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
-  comment_format:
-    - xform/jy/y/
-    - xform/j/y/
-    - xform/z/j/
-    - xform/c/ch/
-    - xform/aa$/a/
-    - xform/eu/iu/
-    - xform/eo/eu/
-    - xform/oe/eu/
-    - xform/em/im/
-    - xform/ep/ip/
+  comment_format: *comment_rules
 
 punctuator:
   import_preset: default


### PR DESCRIPTION
1. 补充遗漏的声母简拼ch
2. 修正普通话（汉语拼音）反查时的提示错误。例如：「家 gaa gu」应是「家 ga gu」，「亚 aa nga」应是「亚 a nga」。和上次 20124c3dd621cf090e57c89455a448990be380df 的解决办法相同。两处comment_format可以共享同一份规则。