### PR TITLE
pinyin: 修復含有「沒」的多音詞

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -28,7 +28,7 @@
 
 ---
 name: luna_pinyin
-version: "2016.06.12"
+version: "2016.07.10"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -59710,26 +59710,29 @@ use_preset_vocabulary: true
 沉陷	chen xian
 沏油	qu you
 沐浴露	mu yu lu
-沒下	mo xia
+沒下	mei xia
+沒下	mo xia	1%
 沒不煞	mo bu sha
 沒世	mo shi
 沒世不忘	mo shi bu wang
 沒世難忘	mo shi nan wang
 沒乾沒淨	mei gan mei jing
 沒乾淨	mei gan jing
+沒亂	mei luan	5%
 沒亂	mo luan
 沒亂死	mo luan si
 沒亂殺	mo luan sha
 沒亂煞	mo luan sha
 沒亂裏	mo luan li
-沒了	mo le
+沒了	mei le
+沒了	mo le	1%
 沒了期	mei liao qi
 沒了當	mei liao dang
 沒了結處	mei liao jie chu
 沒了落	mei liao luo
 沒事哏	mei shi hen
 沒人	mei ren
-沒人	mo ren
+沒人	mo ren	1%
 沒什麼	mei shen me
 沒什麼要緊	mei shen me yao jin
 沒入	mo ru
@@ -59739,6 +59742,7 @@ use_preset_vocabulary: true
 沒命似的	mei ming si de
 沒嚼頭	mei jue tou
 沒地	mei de
+沒地	mei di
 沒地	mo di
 沒地裏巡檢	mei di li xun jian
 沒地里	mei de li
@@ -59756,6 +59760,7 @@ use_preset_vocabulary: true
 沒揣的	mo chuai di
 沒撩沒亂	mei liao mo luan
 沒撻煞	mei ta sha
+沒收	mei shou	5%
 沒收	mo shou
 沒是哏	mei shi hen
 沒有什麼	mei you shen me
@@ -59764,7 +59769,8 @@ use_preset_vocabulary: true
 沒有長羽毛就忘了根本	mei you zhang yu mao jiu wang le gen ben
 沒查沒利	mei zha mei li
 沒死以聞	mo si yi wen
-沒水	mo shui
+沒水	mei shui
+沒水	mo shui	5%
 沒沒	mo mo
 沒沒無聞	mo mo wu wen
 沒海履地	mo hai lv di

--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -23,7 +23,7 @@
 
 ---
 name: terra_pinyin
-version: "2016.06.12"
+version: "2016.07.10"
 sort: by_weight
 use_preset_vocabulary: true
 max_phrase_length: 7
@@ -74695,7 +74695,8 @@ min_phrase_weight: 100
 沐猴冠冕	mu4 hou2 guan4 mian3
 沐猴衣冠	mu4 hou2 yi1 guan1
 沒一頓飯的工夫	mei2 yi2 dun4 fan4 de5 gong1 fu5
-沒下	mo4 xia4
+沒下	mei2 xia4
+沒下	mo4 xia4	1%
 沒不煞	mo4 bu4 sha1
 沒世	mo4 shi4
 沒世不忘	mo4 shi4 bu2 wang4
@@ -74709,7 +74710,8 @@ min_phrase_weight: 100
 沒亂殺	mo4 luan4 sha1
 沒亂煞	mo4 luan4 sha1
 沒亂裏	mo4 luan4 li3
-沒了	mo4 le5
+沒了	mei2 le5
+沒了	mo4 le5	1%
 沒了主意	mei2 le5 zhu3 yi5
 沒了期	mei2 liao3 qi2
 沒了當	mei2 liao3 dang4
@@ -74718,7 +74720,7 @@ min_phrase_weight: 100
 沒事兒	mei2 shi4 r5
 沒事哏	mei2 shi4 hen1
 沒人	mei2 ren2
-沒人	mo4 ren2
+沒人	mo4 ren2	1%
 沒人味兒	mei2 ren2 wei4 r5
 沒人當你是啞吧	mei2 ren2 dang4 ni3 shi4 ya3 ba5
 沒人處	mei2 ren2 chu4
@@ -74761,6 +74763,7 @@ min_phrase_weight: 100
 沒嚼頭	mei2 jue2 tou5
 沒圈子跳	mei2 quan1 zi5 tiao4
 沒地	mei2 de5
+沒地	mei2 di4
 沒地	mo4 di4
 沒地裏巡檢	mei2 di4 li3 xun2 jian3
 沒地里	mei2 de5 li3
@@ -74802,6 +74805,7 @@ min_phrase_weight: 100
 沒撻煞	mei2 ta4 sha4
 沒擔當	mei2 dan1 dang1
 沒擺佈處	mei2 bai3 bu4 chu4
+沒收	mei2 shou1	5%
 沒收	mo4 shou1
 沒收煞	mei2 shou1 sha4
 沒散場	mei2 san4 chang2
@@ -74827,7 +74831,8 @@ min_phrase_weight: 100
 沒正經	mei2 zheng4 jing5
 沒正經的事	mei2 zheng4 jing5 de5 shi4
 沒死以聞	mo4 si3 yi3 wen2
-沒水	mo4 shui3
+沒水	mei2 shui3
+沒水	mo4 shui3	5%
 沒沒	mo4 mo4
 沒沒無聞	mo4 mo4 wu2 wen2
 沒法子	mei2 fa2 zi5


### PR DESCRIPTION
https://www.v2ex.com/t/286896 回覆 #85:  moren -> 能打出 没人

然而這是個多音詞： 
https://www.moedict.tw/%E6%B2%92%E4%BA%BA 
沒人 mò rén 
能潛水的人。 
宋·蘇軾〈日喻〉：「南方多沒人。日與水居也，七歲而能涉，十歲而能浮，十五而能沒矣。」 

不過這個義項應該降低詞頻。同時修改其他一些含有「沒」的兩讀的詞。