### PR TITLE
將朙月拼音及地球拼音中的「xve」修正為「xue」。

### DIFF
--- a/preset/luna_pinyin.dict.yaml
+++ b/preset/luna_pinyin.dict.yaml
@@ -51606,7 +51606,7 @@ use_preset_vocabulary: true
 南極地區	nan ji di qu
 南極大陸	nan ji da lu
 南樂	nan yue
-南樓詠謔	nan lou yong xve
+南樓詠謔	nan lou yong xue
 南橘北枳	nan ju bei zhi
 南水北調	nan shui bei diao
 南無	na mo
@@ -52661,7 +52661,7 @@ use_preset_vocabulary: true
 嘬炙	chuai zhi
 嘲哳	zhao zha
 嘲啾	chao jiu
-嘲謔	chao xve
+嘲謔	chao xue
 嘴上抹石灰	zui shang mo shi hui
 嘴吶	zui na
 嘴啃地	zui ken di
@@ -56162,7 +56162,7 @@ use_preset_vocabulary: true
 戲戟	hui ji
 戲提調	xi ti diao
 戲行	xi hang
-戲謔	xi xve
+戲謔	xi xue
 戴天之仇	dai tian zhi chou
 戴天履地	dai tian lv di
 戴憑重席	dai ping chong xi
@@ -66385,7 +66385,7 @@ use_preset_vocabulary: true
 調諧	tiao xie
 調諧器	tiao xie qi
 調謊	diao huang
-調謔	tiao xve
+調謔	tiao xue
 調護	tiao hu
 調變	tiao bian
 調貼	tiao tie
@@ -66475,10 +66475,10 @@ use_preset_vocabulary: true
 謐爾	mi er
 謐謐	mi mi
 謐靜	mi jing
-謔稱	xve cheng
-謔而不虐	xve er bu nve
-謔親	xve qin
-謔謔	xve xve
+謔稱	xue cheng
+謔而不虐	xue er bu nve
+謔親	xue qin
+謔謔	xue xue
 謖爾	su er
 謖謖	su su
 謙洽	qian qia

--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -57734,7 +57734,7 @@ min_phrase_weight: 100
 嘲諷	chao2 feng4
 嘲諷漫罵	chao2 feng4 man4 ma4
 嘲謔	chao2 nve4
-嘲謔	chao2 xve4
+嘲謔	chao2 xue4
 嘲風弄月	chao2 feng1 nong4 yue4
 嘴上抹石灰	zui3 shang5 mo3 shi2 hui1
 嘴上無毛	zui3 shang5 wu2 mao2
@@ -90375,9 +90375,9 @@ min_phrase_weight: 100
 謔稱	nve4 cheng1
 謔稱	xue4 cheng1
 謔親	nve4 qin1
-謔親	xve4 qin1
+謔親	xue4 qin1
 謔謔	nve4 nve4
-謔謔	xve4 xve4
+謔謔	xue4 xue4
 謙和	qian1 he2
 謙洽	qian1 qia4
 謙洽	qian1 xia2


### PR DESCRIPTION
根據《漢語拼音方案》，「x」前面的「ü」應該寫為「u」。