### PR TITLE
將「er1」及「er5」修正成「r5」

### DIFF
--- a/preset/terra_pinyin.dict.yaml
+++ b/preset/terra_pinyin.dict.yaml
@@ -52090,7 +52090,7 @@ min_phrase_weight: 100
 兒寬	ni2 kuan1
 兒息	er2 xi2
 兒童樂園	er2 tong2 le4 yuan2
-兔兒不喫窠邊草	tu4 er1 bu4 chi1 ke1 bian1 cao3
+兔兒不喫窠邊草	tu4 r5 bu4 chi1 ke1 bian1 cao3
 兔子	tu4 zi5
 兔子不吃窩邊草	tu4 zi5 bu4 chi1 wo1 bian1 cao3
 兔寶寶	tu4 bao3 bao5
@@ -60380,7 +60380,7 @@ min_phrase_weight: 100
 奔騰	ben1 teng2
 奔騰澎湃	ben1 teng2 peng1 pai4
 套交情	tao4 jiao1 qing5
-套兒	tao4 er5
+套兒	tao4 r5
 套口供	tao4 kou3 gong4
 套套	tao4 tao5
 套子	tao4 zi5
@@ -66860,7 +66860,7 @@ min_phrase_weight: 100
 打麻將	da3 ma2 jiang4
 打點	da3 dian5
 打點行裝	da3 dian5 xing2 zhuang1
-打鼓兒的	da3 gu3 er1 de1
+打鼓兒的	da3 gu3 r5 de1
 托勒密	tuo1 le4 mi4
 托勒密王	tuo1 le4 mi4 wang2
 托勒玫	tuo1 le4 mei2
@@ -74974,7 +74974,7 @@ min_phrase_weight: 100
 河渠	he2 qu2
 河落海乾	he2 lao4 hai3 gan1
 河蚌	he2 bang4
-河裏孩兒岸上娘	he2 li3 ha2 er1 an4 shang4 niang2
+河裏孩兒岸上娘	he2 li3 ha2 r5 an4 shang4 niang2
 河西堡	he2 xi1 pu4
 河西堡鎮	he2 xi1 pu3 zhen4
 河間市	he2 jian1 shi4


### PR DESCRIPTION
「er1」應該是錯誤把萌典的「ㄦ」轉換成「er1」，其實應該轉換成「r5」。