### PR TITLE
路径：给 *.conf 指定为 brise_dir

### DIFF
--- a/all-packages.conf
+++ b/all-packages.conf
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 package_list=()
-source preset-packages.conf
-source extra-packages.conf
+source "${brise_dir}/preset-packages.conf"
+source "${brise_dir}/extra-packages.conf"


### PR DESCRIPTION
为什么不呢？
可解决在外部路径中 *.conf 出现「No such file or directory」的问题。